### PR TITLE
MORPH-5532: Improve README with full feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,80 @@
 # Morpheus XCP-ng Plugin
-This library provides an integration between XCP-ng and Morpheus. A `CloudProvider` (for syncing the Cloud related objects), a `ProvisionProvider` (for provisioning into XCP-ng), and a `BackupProvider` (for vm snapshots and backups) are implemented in this plugin.
 
-### Requirements
-XCP-ng - Version 8.2 or greater
+This plugin provides a full integration between [XCP-ng / Citrix XenServer](https://xcp-ng.org) and [Morpheus](https://morpheusdata.com). It enables cloud inventory sync, VM provisioning, VM import, hypervisor console access, and snapshot-based backups from within the Morpheus platform.
 
-### Building
-`./gradlew shadowJar`
+## Requirements
 
-### Configuration
-The following options are required when setting up a Morpheus Cloud to an XCP-ng environment using this plugin:
-1. API URL: XCP-ng host URL (i.e. https://10.100.10.100)
-2. Custom Port (optional, defaults to 443)
-2. Username
-3. Password
+| Component | Minimum Version |
+|-----------|----------------|
+| Morpheus | 9.0.0 |
 
-#### Features
-Cloud sync: hosts, images, networks, datastores, pools, and virtual machines are fetched from XCP-ng and inventoried in Morpheus. Any additions, updates, and removals to these objects are reflected in Morpheus.
+## Installation
 
-Provisioning: Virtual machines can be provisioned from Morpheus via this plugin.
+1. Download the latest `.jar` from the [Releases](https://github.com/gomorpheus/morpheus-xenserver-plugin/releases) page, or [build it yourself](#building).
+2. In Morpheus, navigate to **Administration → Integrations → Plugins**.
+3. Click **Browse** and upload the `.jar` file.
+4. The **XCP-ng** cloud type will appear after the plugin loads.
+
+## Configuration
+
+When adding an XCP-ng cloud in Morpheus (**Infrastructure → Clouds → Add Cloud**), provide the following:
+
+| Field | Description |
+|-------|-------------|
+| **API URL** | XCP-ng or XenServer pool master endpoint |
+| **Custom Port** | Optional API port override |
+| **Credentials** | Select local credentials or a stored username/password credential |
+| **Username** | XCP-ng or XenServer username |
+| **Password** | XCP-ng or XenServer password |
+| **Inventory Existing Instances** | Inventory existing virtual machines |
+| **Enable Hypervisor Console** | Enable VNC console access through the hypervisor |
+
+Credentials can also be stored as a Morpheus [Credential](https://docs.morpheusdata.com/en/latest/administration/credentials/credentials.html) and selected at cloud setup time.
+
+## Features
+
+### Cloud Sync
+
+The following resources are discovered and kept in sync from XCP-ng or XenServer:
+
+- **Hosts** — XCP-ng hypervisor hosts
+- **Images** — VM templates and virtual images available for provisioning
+- **Networks** — XCP-ng networks exposed to Morpheus
+- **Datastores** — storage repositories available to the pool
+- **Pools** — XCP-ng resource pools
+- **Virtual Machines** — managed and unmanaged VMs, including power state and metadata
+
+Any additions, updates, and removals in XCP-ng or XenServer are automatically reflected in Morpheus on the next sync cycle.
+
+### Provisioning
+
+Virtual machines can be provisioned into XCP-ng or XenServer directly from Morpheus using standard instance types and layouts. Supported operations include:
+
+- Create, start, stop, and delete VMs
+- Resize CPU, memory, disks, and network interfaces
+- Clone from selected VM images and snapshots
+- Import existing workloads into Morpheus-managed images
+- Provision Linux, Windows, Docker host, and Kubernetes node server types
+- Use cloud-init customization and optional hypervisor console access
+
+### Backups
+
+XCP-ng VM snapshots are supported via the Morpheus backup framework. Supported operations include:
+
+- Create VM snapshot backups
+- Copy snapshot backups to Morpheus backup storage
+- Download exported backup archives
+- Delete backup snapshots and exported archives
+- Restore snapshots to existing or new workloads
+
+## Building
+
+```bash
+./gradlew shadowJar
+```
+
+The plugin JAR will be written to `build/libs/`.
+
+## License
+
+Copyright 2022 Morpheus Data, LLC. Licensed under the [Apache License, Version 2.0](LICENSE).


### PR DESCRIPTION
Standardizes the plugin README as part of the documentation standardization initiative (MORPH-5532). Relates to MORPH-11543. Grounded in the providers the plugin registers and follows the structure approved in the Nutanix Prism plugin README.